### PR TITLE
Added support for Fine-Grained Access Control (FGAC) on Change Streams

### DIFF
--- a/v2/datastream-to-spanner/src/main/java/org/apache/beam/sdk/io/gcp/spanner/ExposedSpannerConfig.java
+++ b/v2/datastream-to-spanner/src/main/java/org/apache/beam/sdk/io/gcp/spanner/ExposedSpannerConfig.java
@@ -42,7 +42,7 @@ public class ExposedSpannerConfig extends SpannerConfig {
 
   private final ValueProvider<String> databaseId;
 
-  private final String databaseRole;
+  private final ValueProvider<String> databaseRole;
 
   private final ValueProvider<String> host;
 
@@ -68,7 +68,7 @@ public class ExposedSpannerConfig extends SpannerConfig {
       @Nullable ValueProvider<String> projectId,
       @Nullable ValueProvider<String> instanceId,
       @Nullable ValueProvider<String> databaseId,
-      @Nullable String databaseRole,
+      @Nullable ValueProvider<String> databaseRole,
       @Nullable ValueProvider<String> host,
       @Nullable ValueProvider<String> emulatorHost,
       @Nullable ValueProvider<Boolean> isLocalChannelProvider,
@@ -114,7 +114,8 @@ public class ExposedSpannerConfig extends SpannerConfig {
   }
 
   @Nullable
-  public String getDatabaseRole() {
+  @Override
+  public ValueProvider<String> getDatabaseRole() {
     return databaseRole;
   }
 
@@ -293,7 +294,7 @@ public class ExposedSpannerConfig extends SpannerConfig {
     private ValueProvider<String> projectId;
     private ValueProvider<String> instanceId;
     private ValueProvider<String> databaseId;
-    private String databaseRole;
+    private ValueProvider<String> databaseRole;
     private ValueProvider<String> host;
     private ValueProvider<String> emulatorHost;
     private ValueProvider<Boolean> isLocalChannelProvider;
@@ -342,7 +343,8 @@ public class ExposedSpannerConfig extends SpannerConfig {
       return this;
     }
 
-    ExposedSpannerConfig.Builder setDatabaseRole(String databaseRole) {
+    @Override
+    ExposedSpannerConfig.Builder setDatabaseRole(ValueProvider<String> databaseRole) {
       this.databaseRole = databaseRole;
       return this;
     }

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToBigQueryOptions.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToBigQueryOptions.java
@@ -98,8 +98,18 @@ public interface SpannerChangeStreamsToBigQueryOptions extends DataflowPipelineO
 
   void setSpannerChangeStreamName(String value);
 
-  @TemplateParameter.Enum(
+  @TemplateParameter.Text(
       order = 8,
+      description = "Spanner database role",
+      helpText = "Database role user assumes while reading from the change stream. The database role should"
+          + " have required privileges to read from change stream. If a database role is not"
+          + " specified, the user should have required IAM permissions to read from the database.")
+  String getSpannerDatabaseRole();
+
+  void setSpannerDatabaseRole(String spannerDatabaseRole);
+
+  @TemplateParameter.Enum(
+      order = 9,
       enumOptions = {"LOW", "MEDIUM", "HIGH"},
       optional = true,
       description = "Priority for Spanner RPC invocations",
@@ -111,7 +121,7 @@ public interface SpannerChangeStreamsToBigQueryOptions extends DataflowPipelineO
   void setRpcPriority(RpcPriority value);
 
   @TemplateParameter.Text(
-      order = 9,
+      order = 10,
       optional = true,
       description = "Cloud Spanner Endpoint to call",
       helpText = "The Cloud Spanner endpoint to call in the template. Only used for testing.",
@@ -121,7 +131,7 @@ public interface SpannerChangeStreamsToBigQueryOptions extends DataflowPipelineO
   void setSpannerHost(String value);
 
   @TemplateParameter.DateTime(
-      order = 10,
+      order = 11,
       optional = true,
       description = "The timestamp to read change streams from",
       helpText =
@@ -134,7 +144,7 @@ public interface SpannerChangeStreamsToBigQueryOptions extends DataflowPipelineO
   void setStartTimestamp(String startTimestamp);
 
   @TemplateParameter.DateTime(
-      order = 11,
+      order = 12,
       optional = true,
       description = "The timestamp to read change streams to",
       helpText =
@@ -147,7 +157,7 @@ public interface SpannerChangeStreamsToBigQueryOptions extends DataflowPipelineO
   void setEndTimestamp(String startTimestamp);
 
   @TemplateParameter.Text(
-      order = 12,
+      order = 13,
       description = "BigQuery dataset",
       helpText = "The BigQuery dataset for change streams output.")
   @Validation.Required
@@ -156,7 +166,7 @@ public interface SpannerChangeStreamsToBigQueryOptions extends DataflowPipelineO
   void setBigQueryDataset(String value);
 
   @TemplateParameter.ProjectId(
-      order = 13,
+      order = 14,
       optional = true,
       description = "BigQuery project ID",
       helpText = "The BigQuery Project. Default is the project for the Dataflow job.")
@@ -166,7 +176,7 @@ public interface SpannerChangeStreamsToBigQueryOptions extends DataflowPipelineO
   void setBigQueryProjectId(String value);
 
   @TemplateParameter.Text(
-      order = 14,
+      order = 15,
       optional = true,
       description = "BigQuery table name Template",
       helpText = "The Template for the BigQuery table name that contains the change log")
@@ -176,7 +186,7 @@ public interface SpannerChangeStreamsToBigQueryOptions extends DataflowPipelineO
   void setBigQueryChangelogTableNameTemplate(String value);
 
   @TemplateParameter.GcsWriteFolder(
-      order = 15,
+      order = 16,
       optional = true,
       description = "Dead letter queue directory",
       helpText =
@@ -187,7 +197,7 @@ public interface SpannerChangeStreamsToBigQueryOptions extends DataflowPipelineO
   void setDlqDirectory(String value);
 
   @TemplateParameter.Integer(
-      order = 16,
+      order = 17,
       optional = true,
       description = "Dead letter queue retry minutes",
       helpText = "The number of minutes between dead letter queue retries. Defaults to 10.")
@@ -198,7 +208,7 @@ public interface SpannerChangeStreamsToBigQueryOptions extends DataflowPipelineO
 
   // TODO(haikuo-google): Test this in UIF test.
   @TemplateParameter.Text(
-      order = 17,
+      order = 18,
       optional = true,
       description = "Fields to be ignored",
       helpText =

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToGcsOptions.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/options/SpannerChangeStreamsToGcsOptions.java
@@ -104,8 +104,19 @@ public interface SpannerChangeStreamsToGcsOptions
 
   void setSpannerChangeStreamName(String spannerChangeStreamName);
 
-  @TemplateParameter.DateTime(
+  @TemplateParameter.Text(
       order = 8,
+      description = "Spanner database role",
+      helpText =
+          "Database role user assumes while reading from the change stream. The database role should"
+              + " have required privileges to read from change stream. If a database role is not"
+              + " specified, the user should have required IAM permissions to read from the database.")
+  String getSpannerDatabaseRole();
+
+  void setSpannerDatabaseRole(String spannerDatabaseRole);
+
+  @TemplateParameter.DateTime(
+      order = 9,
       optional = true,
       description = "The timestamp to read change streams from",
       helpText =
@@ -118,7 +129,7 @@ public interface SpannerChangeStreamsToGcsOptions
   void setStartTimestamp(String startTimestamp);
 
   @TemplateParameter.DateTime(
-      order = 9,
+      order = 10,
       optional = true,
       description = "The timestamp to read change streams to",
       helpText =
@@ -131,7 +142,7 @@ public interface SpannerChangeStreamsToGcsOptions
   void setEndTimestamp(String startTimestamp);
 
   @TemplateParameter.Text(
-      order = 10,
+      order = 11,
       optional = true,
       description = "Cloud Spanner Endpoint to call",
       helpText = "The Cloud Spanner endpoint to call in the template. Only used for testing.",
@@ -142,7 +153,7 @@ public interface SpannerChangeStreamsToGcsOptions
   void setSpannerHost(String value);
 
   @TemplateParameter.Enum(
-      order = 11,
+      order = 12,
       enumOptions = {"TEXT", "AVRO"},
       optional = true,
       description = "Output file format",
@@ -154,7 +165,7 @@ public interface SpannerChangeStreamsToGcsOptions
   void setOutputFileFormat(FileFormat outputFileFormat);
 
   @TemplateParameter.Duration(
-      order = 12,
+      order = 13,
       optional = true,
       description = "Window duration",
       helpText =
@@ -167,7 +178,7 @@ public interface SpannerChangeStreamsToGcsOptions
   void setWindowDuration(String windowDuration);
 
   @TemplateParameter.Enum(
-      order = 13,
+      order = 14,
       enumOptions = {"LOW", "MEDIUM", "HIGH"},
       optional = true,
       description = "Priority for Spanner RPC invocations",

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToGcs.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToGcs.java
@@ -111,15 +111,21 @@ public class SpannerChangeStreamsToGcs {
             : options.getSpannerMetadataTableName();
 
     final RpcPriority rpcPriority = options.getRpcPriority();
+    SpannerConfig spannerConfig = SpannerConfig.create()
+        .withHost(ValueProvider.StaticValueProvider.of(options.getSpannerHost()))
+        .withProjectId(projectId)
+        .withInstanceId(instanceId)
+        .withDatabaseId(databaseId);
+    // Propagate database role for fine-grained access control on change stream.
+    if (options.getSpannerDatabaseRole() != null){
+      LOG.info("Setting database role on SpannerConfig: " + options.getSpannerDatabaseRole());
+      spannerConfig = spannerConfig.withDatabaseRole(ValueProvider.StaticValueProvider.of(options.getSpannerDatabaseRole()));
+    }
+    LOG.info("Created SpannerConfig: " + spannerConfig);
     pipeline
         .apply(
             SpannerIO.readChangeStream()
-                .withSpannerConfig(
-                    SpannerConfig.create()
-                        .withHost(ValueProvider.StaticValueProvider.of(options.getSpannerHost()))
-                        .withProjectId(projectId)
-                        .withInstanceId(instanceId)
-                        .withDatabaseId(databaseId))
+                .withSpannerConfig(spannerConfig)
                 .withMetadataInstance(metadataInstanceId)
                 .withMetadataDatabase(metadataDatabaseId)
                 .withChangeStreamName(changeStreamName)

--- a/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SpannerChangeStreamsToBigQuery.java
+++ b/v2/googlecloud-to-googlecloud/src/main/java/com/google/cloud/teleport/v2/templates/spannerchangestreamstobigquery/SpannerChangeStreamsToBigQuery.java
@@ -176,6 +176,10 @@ public final class SpannerChangeStreamsToBigQuery {
             .withInstanceId(options.getSpannerInstanceId())
             .withDatabaseId(options.getSpannerDatabase())
             .withRpcPriority(options.getRpcPriority());
+    // Propagate database role for fine-grained access control on change stream.
+    if (options.getSpannerDatabaseRole() != null){
+      spannerConfig = spannerConfig.withDatabaseRole(ValueProvider.StaticValueProvider.of(options.getSpannerDatabaseRole()));
+    }
 
     SpannerIO.ReadChangeStream readChangeStream =
         SpannerIO.readChangeStream()

--- a/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToGcsTest.java
+++ b/v2/googlecloud-to-googlecloud/src/test/java/com/google/cloud/teleport/v2/templates/SpannerChangeStreamsToGcsTest.java
@@ -73,8 +73,6 @@ public final class SpannerChangeStreamsToGcsTest {
   private static final String AVRO_FILENAME_PREFIX = "avro-output-";
   private static final String TEXT_FILENAME_PREFIX = "text-output-";
   private static final Integer NUM_SHARDS = 1;
-  private static final String TEST_PROJECT = "span-cloud-testing";
-  private static final String TEST_INSTANCE = "changestream";
   private static final String TEST_DATABASE_PREFIX = "testdbchangestreams";
   private static final String TEST_TABLE = "Users";
   private static final String TEST_CHANGE_STREAM = "UsersStream";
@@ -281,15 +279,108 @@ public final class SpannerChangeStreamsToGcsTest {
     spannerServer.getDbClient(testDatabase).write(mutations);
 
     Timestamp endTimestamp = Timestamp.now();
+    SpannerConfig spannerConfig = spannerServer.getSpannerConfig(testDatabase);
 
     SpannerChangeStreamsToGcsOptions options =
         PipelineOptionsFactory.create().as(SpannerChangeStreamsToGcsOptions.class);
-    options.setSpannerProjectId(TEST_PROJECT);
-    options.setSpannerInstanceId(TEST_INSTANCE);
+    options.setSpannerHost(spannerConfig.getHost().get());
+    options.setSpannerProjectId(spannerConfig.getProjectId().get());
+    options.setSpannerInstanceId(spannerConfig.getInstanceId().get());
     options.setSpannerDatabase(testDatabase);
-    options.setSpannerMetadataInstanceId(TEST_INSTANCE);
+    options.setSpannerMetadataInstanceId(spannerConfig.getInstanceId().get());
     options.setSpannerMetadataDatabase(testDatabase);
     options.setSpannerChangeStreamName(TEST_CHANGE_STREAM);
+
+    options.setStartTimestamp(startTimestamp.toString());
+    options.setEndTimestamp(endTimestamp.toString());
+    List<String> experiments = new ArrayList<String>();
+    options.setExperiments(experiments);
+
+    options.setOutputFileFormat(FileFormat.AVRO);
+    options.setGcsOutputDirectory(fakeDir);
+    options.setOutputFilenamePrefix(AVRO_FILENAME_PREFIX);
+    options.setNumShards(NUM_SHARDS);
+    options.setTempLocation(fakeTempLocation);
+
+    // Run the pipeline.
+    PipelineResult result = run(options);
+    result.waitUntilFinish();
+
+    // Read from the output Avro file to assert that 1 data change record has been generated.
+    PCollection<com.google.cloud.teleport.v2.DataChangeRecord> dataChangeRecords =
+        pipeline.apply(
+            "readRecords",
+            AvroIO.read(com.google.cloud.teleport.v2.DataChangeRecord.class)
+                .from(fakeDir + "/avro-output-*.avro"));
+    PAssert.that(dataChangeRecords).satisfies(new VerifyDataChangeRecordAvro());
+    pipeline.run();
+
+    // Drop the database.
+    spannerServer.dropDatabase(testDatabase);
+  }
+
+  @Test
+  @Category(IntegrationTest.class)
+  // This test can only be run locally with the following command:
+  // mvn -Dexcluded.spanner.tests="" -Dtest=SpannerChangeStreamsToGcsTest test
+  public void testWriteToGCSAvroWithDatabaseRole() throws Exception {
+    // Create a test database.
+    String testDatabase = generateDatabaseName();
+    fakeDir = tmpDir.newFolder("output").getAbsolutePath();
+    fakeTempLocation = tmpDir.newFolder("temporaryLocation").getAbsolutePath();
+
+    spannerServer.dropDatabase(testDatabase);
+
+    // Define test role.
+    final String testRole = "test_role";
+
+    // Create a table.
+    List<String> statements = new ArrayList<String>();
+    final String createTable =
+        "CREATE TABLE "
+            + TEST_TABLE
+            + " ("
+            + "user_id INT64 NOT NULL,"
+            + "name STRING(MAX) "
+            + ") PRIMARY KEY(user_id)";
+    final String createChangeStream = "CREATE CHANGE STREAM " + TEST_CHANGE_STREAM + " FOR Users";
+
+    // Set up roles and privileges.
+    final String createRole = "CREATE ROLE " + testRole;
+    final String grantCSPrivilege = "GRANT SELECT ON CHANGE STREAM " + TEST_CHANGE_STREAM + " TO ROLE " + testRole;
+    final String grantTVFPrivilege = "GRANT EXECUTE ON TABLE FUNCTION READ_" + TEST_CHANGE_STREAM + " TO ROLE " + testRole;
+    statements.add(createTable);
+    statements.add(createChangeStream);
+    statements.add(createRole);
+    statements.add(grantCSPrivilege);
+    statements.add(grantTVFPrivilege);
+
+    spannerServer.createDatabase(testDatabase, statements);
+
+    Timestamp startTimestamp = Timestamp.now();
+
+    // Create a mutation for the table that will generate 1 data change record.
+    List<Mutation> mutations = new ArrayList<>();
+    mutations.add(
+        Mutation.newInsertBuilder(TEST_TABLE).set("user_id").to(1).set("name").to("Name1").build());
+    mutations.add(
+        Mutation.newInsertBuilder(TEST_TABLE).set("user_id").to(2).set("name").to("Name2").build());
+
+    spannerServer.getDbClient(testDatabase).write(mutations);
+
+    Timestamp endTimestamp = Timestamp.now();
+    SpannerConfig spannerConfig = spannerServer.getSpannerConfig(testDatabase);
+
+    SpannerChangeStreamsToGcsOptions options =
+        PipelineOptionsFactory.create().as(SpannerChangeStreamsToGcsOptions.class);
+    options.setSpannerHost(spannerConfig.getHost().get());
+    options.setSpannerProjectId(spannerConfig.getProjectId().get());
+    options.setSpannerInstanceId(spannerConfig.getInstanceId().get());
+    options.setSpannerDatabase(testDatabase);
+    options.setSpannerMetadataInstanceId(spannerConfig.getInstanceId().get());
+    options.setSpannerMetadataDatabase(testDatabase);
+    options.setSpannerChangeStreamName(TEST_CHANGE_STREAM);
+    options.setSpannerDatabaseRole(testRole);
 
     options.setStartTimestamp(startTimestamp.toString());
     options.setEndTimestamp(endTimestamp.toString());
@@ -357,13 +448,15 @@ public final class SpannerChangeStreamsToGcsTest {
     spannerServer.getDbClient(testDatabase).write(mutations);
 
     Timestamp endTimestamp = Timestamp.now();
+    SpannerConfig spannerConfig = spannerServer.getSpannerConfig(testDatabase);
 
     SpannerChangeStreamsToGcsOptions options =
         PipelineOptionsFactory.create().as(SpannerChangeStreamsToGcsOptions.class);
-    options.setSpannerProjectId(TEST_PROJECT);
-    options.setSpannerInstanceId(TEST_INSTANCE);
+    options.setSpannerHost(spannerConfig.getHost().get());
+    options.setSpannerProjectId(spannerConfig.getProjectId().get());
+    options.setSpannerInstanceId(spannerConfig.getInstanceId().get());
     options.setSpannerDatabase(testDatabase);
-    options.setSpannerMetadataInstanceId(TEST_INSTANCE);
+    options.setSpannerMetadataInstanceId(spannerConfig.getInstanceId().get());
     options.setSpannerMetadataDatabase(testDatabase);
     options.setSpannerChangeStreamName(TEST_CHANGE_STREAM);
 

--- a/v2/pom.xml
+++ b/v2/pom.xml
@@ -59,6 +59,13 @@
                 <version>2.3.0</version>
             </dependency>
             <dependency>
+                <groupId>com.google.cloud</groupId>
+                <artifactId>google-cloud-spanner-bom</artifactId>
+                <version>6.30.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.google.api</groupId>
                 <artifactId>gax-grpc</artifactId>
                 <version>2.3.0</version>


### PR DESCRIPTION
Added Fine-grained access control for Google Dataflow change streams.  NOTE: This commit is dependent on (yet to be released) Apache Beam 2.44.0